### PR TITLE
Remove unused string resource

### DIFF
--- a/hyperion-simple-item/src/main/res/values/strings.xml
+++ b/hyperion-simple-item/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-  <string name="app_name">hyperion-simple-item</string>
-</resources>


### PR DESCRIPTION
This PR deletes unused `strings.xml` on `hyperion-simple-item` module.
The file contains `app_name` string resource which may replace app label of users.
