### PR TITLE
disabled nested scroll for simple items recyclerview

### DIFF
--- a/hyperion-simple-item/src/main/java/com/github/takahirom/hyperion/plugin/simpleitem/SimpleItemModule.java
+++ b/hyperion-simple-item/src/main/java/com/github/takahirom/hyperion/plugin/simpleitem/SimpleItemModule.java
@@ -22,6 +22,7 @@ class SimpleItemModule extends PluginModule {
       @NonNull ViewGroup parent) {
     final RecyclerView recyclerView = new RecyclerView(parent.getContext());
     recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+    recyclerView.setNestedScrollingEnabled(false);
     final SimpleItemListAdapter adapter = new SimpleItemListAdapter(layoutInflater);
     recyclerView.setAdapter(adapter);
     final DividerItemDecoration dividerItemDecoration =


### PR DESCRIPTION
Hey! 👋 
I faced a small UI issue with nested scroll - if there are several Hyperion plugins in the drawer and several items in SimpleItem RecyclerView. RecyclerView becomes scrollable inside parent Hyperion's ScrollView and it's really uncomfortable to use.

Here is a fix 😃✌🏽